### PR TITLE
Fix empty array expansion under bash 3.2 set -u

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ else
         --sign "$SIGN_IDENTITY" \
         --options runtime \
         --timestamp \
-        "${ENTITLEMENTS_ARGS[@]}" \
+        ${ENTITLEMENTS_ARGS[@]+"${ENTITLEMENTS_ARGS[@]}"} \
         "${APP_BUNDLE}"
 fi
 


### PR DESCRIPTION
macOS ships bash 3.2, which treats empty array expansion as unbound under set -u. Use ${arr[@]+"${arr[@]}"} pattern to safely expand ENTITLEMENTS_ARGS when empty.