### PR TITLE
Use ditto zip for signed artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,11 +162,17 @@ jobs:
           xcrun stapler validate ClaudeUsage.app
           spctl -a -vvv -t execute ClaudeUsage.app
 
+      - name: Package signed app
+        run: |
+          # Create zip with ditto to preserve code signature and extended attributes
+          # (actions/upload-artifact's internal zip strips macOS metadata)
+          ditto -c -k --sequesterRsrc --keepParent ClaudeUsage.app ClaudeUsage-signed.zip
+
       - name: Upload signed app
         uses: actions/upload-artifact@v4
         with:
-          name: ClaudeUsage-signed.app
-          path: ClaudeUsage.app/
+          name: ClaudeUsage-signed
+          path: ClaudeUsage-signed.zip
           retention-days: 30
 
       - name: Clean up signing artifacts


### PR DESCRIPTION
## Summary

- Package the signed, stapled .app into a ditto-created zip before uploading as artifact
- `actions/upload-artifact` uses its own zip which strips macOS extended attributes and code signature metadata
- This caused Gatekeeper to reject the downloaded app despite successful notarization and stapling in CI

After this fix, download the `ClaudeUsage-signed` artifact (a zip), then extract with `ditto -x -k`:

```bash
ditto -x -k ClaudeUsage-signed.zip .
open ClaudeUsage.app
```

## Test plan

- [ ] CI sign-and-notarize job passes
- [ ] Downloaded artifact extracts to a properly signed .app
- [ ] `codesign --verify --deep --strict ClaudeUsage.app` passes after extraction
- [ ] App launches without Gatekeeper warning

🤖 Generated with [Claude Code](https://claude.ai/code)