### PR TITLE
Add release workflow and Launch at Login toggle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  release:
+    types: [published]
 
 jobs:
   build-and-test:
+    if: github.event_name != 'release'
     runs-on: macos-15
     timeout-minutes: 15
 
@@ -174,6 +177,171 @@ jobs:
           name: ClaudeUsage-signed
           path: ClaudeUsage-signed.zip
           retention-days: 30
+
+      - name: Clean up signing artifacts
+        if: ${{ always() }}
+        run: |
+          security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" || true
+          rm -f "$RUNNER_TEMP/developer_cert.p12"
+          rm -f "$RUNNER_TEMP/AuthKey.p8"
+
+  # Release job — triggers on GitHub Release creation (tag must be v#.#.#)
+  # Stamps version, builds, signs, notarizes, and uploads zip to the release.
+  # Signing/notarization steps kept in sync with sign-and-notarize job above.
+  release:
+    if: github.event_name == 'release'
+    runs-on: macos-15
+    timeout-minutes: 30
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Validate tag format
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: Tag '$TAG' does not match required format v#.#.# (e.g. v1.2.3)"
+            echo "CFBundleVersion requires dot-separated integers — pre-release suffixes are not allowed."
+            exit 1
+          fi
+          echo "Tag format OK: $TAG"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Stamp version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Stamping version: $VERSION"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" Resources/Info.plist
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION" Resources/Info.plist
+          /usr/libexec/PlistBuddy -c "Print" Resources/Info.plist
+
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/org.swift.swiftpm
+          key: macos-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          restore-keys: macos-spm-
+
+      - name: Build (debug) and test
+        run: |
+          swift build
+          swift test
+        timeout-minutes: 10
+
+      - name: Check signing secrets
+        env:
+          DEVELOPER_CERT_BASE64: ${{ secrets.DEVELOPER_CERT_BASE64 }}
+        run: |
+          if [ -z "$DEVELOPER_CERT_BASE64" ]; then
+            echo "::error::Signing secrets not configured — cannot create release"
+            exit 1
+          fi
+
+      - name: Import code signing certificate
+        env:
+          DEVELOPER_CERT_BASE64: ${{ secrets.DEVELOPER_CERT_BASE64 }}
+          DEVELOPER_CERT_PASSWORD: ${{ secrets.DEVELOPER_CERT_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          CERT_PATH="$RUNNER_TEMP/developer_cert.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          echo -n "$DEVELOPER_CERT_BASE64" | base64 --decode -o "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          security import "$CERT_PATH" \
+            -P "$DEVELOPER_CERT_PASSWORD" \
+            -A -t cert -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+      - name: Build release and sign
+        env:
+          DEVELOPER_SIGNING_IDENTITY: ${{ secrets.DEVELOPER_SIGNING_IDENTITY }}
+        run: |
+          ./build.sh --sign "$DEVELOPER_SIGNING_IDENTITY"
+
+      - name: Verify signature
+        run: |
+          codesign --verify --deep --strict -vvvv ClaudeUsage.app
+          echo "Signature verified successfully"
+
+      - name: Notarize and staple
+        env:
+          APPSTORE_KEY_BASE64: ${{ secrets.APPSTORE_KEY_BASE64 }}
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+        run: |
+          API_KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+          echo -n "$APPSTORE_KEY_BASE64" | base64 --decode -o "$API_KEY_PATH"
+
+          ditto -c -k --sequesterRsrc --keepParent ClaudeUsage.app ClaudeUsage.zip
+
+          NOTARY_OUTPUT=$(xcrun notarytool submit ClaudeUsage.zip \
+            --key "$API_KEY_PATH" \
+            --key-id "$APPSTORE_KEY_ID" \
+            --issuer "$APPSTORE_ISSUER_ID" \
+            --wait \
+            --timeout 20m \
+            --output-format json 2>"$RUNNER_TEMP/notary_stderr.log")
+
+          echo "$NOTARY_OUTPUT"
+          cat "$RUNNER_TEMP/notary_stderr.log" || true
+
+          STATUS=$(echo "$NOTARY_OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status','Unknown'))")
+
+          if [ "$STATUS" != "Accepted" ]; then
+              echo "ERROR: Notarization failed with status: $STATUS"
+              SUBMISSION_ID=$(echo "$NOTARY_OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))")
+              if [ -n "$SUBMISSION_ID" ]; then
+                  echo "--- Notarization log ---"
+                  xcrun notarytool log "$SUBMISSION_ID" \
+                      --key "$API_KEY_PATH" \
+                      --key-id "$APPSTORE_KEY_ID" \
+                      --issuer "$APPSTORE_ISSUER_ID"
+              fi
+              exit 1
+          fi
+
+          xcrun stapler staple ClaudeUsage.app
+
+      - name: Verify notarization
+        run: |
+          xcrun stapler validate ClaudeUsage.app
+          spctl -a -vvv -t execute ClaudeUsage.app
+
+      - name: Package and upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+
+          # Create final zip with ditto (preserves code signature and macOS metadata)
+          ditto -c -k --sequesterRsrc --keepParent ClaudeUsage.app "ClaudeUsage-${TAG}.zip"
+
+          # Generate checksum
+          shasum -a 256 "ClaudeUsage-${TAG}.zip" > "ClaudeUsage-${TAG}.zip.sha256"
+          echo "SHA-256:"
+          cat "ClaudeUsage-${TAG}.zip.sha256"
+
+          # Upload to GitHub Release
+          gh release upload "$TAG" \
+            "ClaudeUsage-${TAG}.zip" \
+            "ClaudeUsage-${TAG}.zip.sha256" \
+            --clobber
 
       - name: Clean up signing artifacts
         if: ${{ always() }}

--- a/Sources/ClaudeUsage/ContentView.swift
+++ b/Sources/ClaudeUsage/ContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import ServiceManagement
 import ClaudeUsageKit
 
 /// The main popover content shown when the menu bar icon is clicked.
@@ -268,6 +269,15 @@ struct ContentView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+
+            Toggle("Launch at Login", isOn: Binding(
+                get: { SMAppService.mainApp.status == .enabled },
+                set: { newValue in
+                    try? newValue ? SMAppService.mainApp.register() : SMAppService.mainApp.unregister()
+                }
+            ))
+            .toggleStyle(.checkbox)
+            .font(.caption)
 
             Button("Reload Credentials") {
                 Task { await service.reloadCredentials() }


### PR DESCRIPTION
Add a CI job that triggers on GitHub Release creation (v#.#.# tags), stamps the version into Info.plist, builds/signs/notarizes, and uploads the zip + SHA-256 checksum to the release. Also add a "Launch at Login" checkbox in the popover footer using SMAppService.