### PR TITLE
Add rateLimitTier support and plan badge formatting

### DIFF
--- a/Sources/ClaudeUsage/ContentView.swift
+++ b/Sources/ClaudeUsage/ContentView.swift
@@ -28,6 +28,7 @@ private struct NoOpNetwork: NetworkSession {
         extraUsage: ExtraUsage(isEnabled: true, monthlyLimit: 10000, usedCredits: 347)
     )
     service.subscriptionType = "max"
+    service.rateLimitTier = "default_claude_max_20x"
     service.lastUpdated = Date().addingTimeInterval(-137)
     return service
 }
@@ -80,7 +81,7 @@ struct ContentView: View {
                 .font(.title3)
                 .fontWeight(.semibold)
 
-            if let tier = service.subscriptionType {
+            if let tier = service.planBadge {
                 Text(tier)
                     .font(.caption)
                     .padding(.horizontal, 6)

--- a/Sources/ClaudeUsageKit/Formatting.swift
+++ b/Sources/ClaudeUsageKit/Formatting.swift
@@ -99,8 +99,13 @@ public func formatMenuBarLabel(
 public func formatPlanBadge(subscriptionType: String?, rateLimitTier: String?) -> String? {
     guard let sub = subscriptionType, !sub.isEmpty else { return nil }
 
+    let isMax = sub.lowercased() == "max"
+
     // Extract multiplier from rateLimitTier (e.g. "default_claude_max_20x" → "20")
-    if let tier = rateLimitTier,
+    // Only applies to Max plans, and the tier must contain "_max_" to avoid false positives.
+    if isMax,
+       let tier = rateLimitTier?.lowercased(),
+       tier.contains("_max_"),
        let match = tier.firstMatch(of: /(\d+)x/) {
         let multiplier = String(match.1)
         // 5x is the base Max tier — just show "Max". Higher tiers get the suffix.

--- a/Sources/ClaudeUsageKit/Formatting.swift
+++ b/Sources/ClaudeUsageKit/Formatting.swift
@@ -90,6 +90,29 @@ public func formatMenuBarLabel(
     return "--%"
 }
 
+// MARK: - Plan Badge
+
+/// Derive a display-friendly plan badge from keychain credential fields.
+/// Uses `rateLimitTier` to distinguish Max variants (e.g. "default_claude_max_20x" → "Max 20x").
+/// Falls back to capitalizing `subscriptionType` when the tier doesn't contain a multiplier.
+/// Returns nil when subscriptionType is nil or empty.
+public func formatPlanBadge(subscriptionType: String?, rateLimitTier: String?) -> String? {
+    guard let sub = subscriptionType, !sub.isEmpty else { return nil }
+
+    // Extract multiplier from rateLimitTier (e.g. "default_claude_max_20x" → "20")
+    if let tier = rateLimitTier,
+       let match = tier.firstMatch(of: /(\d+)x/) {
+        let multiplier = String(match.1)
+        // 5x is the base Max tier — just show "Max". Higher tiers get the suffix.
+        if multiplier != "5" {
+            return "Max \(multiplier)x"
+        }
+    }
+
+    // Capitalize first letter (e.g. "max" → "Max", "pro" → "Pro")
+    return sub.prefix(1).uppercased() + sub.dropFirst()
+}
+
 // MARK: - Credits Formatting
 
 /// Convert a cents value (Double) to a display dollar string.

--- a/Sources/ClaudeUsageKit/UsageService.swift
+++ b/Sources/ClaudeUsageKit/UsageService.swift
@@ -30,6 +30,13 @@ public final class UsageService {
     public var lastUpdated: Date?
     public private(set) var isLoading = false
     public var subscriptionType: String?
+    public var rateLimitTier: String?
+
+    /// Display-friendly plan badge derived from subscriptionType and rateLimitTier.
+    /// E.g. "Pro", "Max", "Max 20x".
+    public var planBadge: String? {
+        formatPlanBadge(subscriptionType: subscriptionType, rateLimitTier: rateLimitTier)
+    }
 
     /// Menu bar label — computed from current state.
     /// Uses `hasAnyUsageData` so we don't imply data is present when all buckets are null.
@@ -178,7 +185,8 @@ public final class UsageService {
                 refreshToken = creds.refreshToken
                 tokenExpiresAt = creds.expiresAt
                 subscriptionType = creds.subscriptionType
-                logger.info("Keychain read succeeded, subscription: \(creds.subscriptionType ?? "unknown")")
+                rateLimitTier = creds.rateLimitTier
+                logger.info("Keychain read succeeded, subscription: \(creds.subscriptionType ?? "unknown"), tier: \(creds.rateLimitTier ?? "unknown")")
             } catch let err as KeychainError {
                 error = .keychain(err)
                 consecutiveFailures += 1
@@ -261,6 +269,7 @@ public final class UsageService {
                                 refreshToken = creds.refreshToken
                                 tokenExpiresAt = creds.expiresAt
                                 subscriptionType = creds.subscriptionType
+                                rateLimitTier = creds.rateLimitTier
                                 await performFetch(retryOn401: false)
                             } catch let keychainErr as KeychainError {
                                 self.error = .keychain(keychainErr)

--- a/Tests/ClaudeUsageTests/FormattingTests.swift
+++ b/Tests/ClaudeUsageTests/FormattingTests.swift
@@ -245,6 +245,22 @@ struct PlanBadgeTests {
         let result = formatPlanBadge(subscriptionType: "max", rateLimitTier: "default_claude_max_100x")
         #expect(result == "Max 100x")
     }
+
+    @Test("Does not return Max badge for non-Max subscription with multiplier-like tier")
+    func nonMaxWithMultiplierTier() {
+        // A non-Max subscription should never produce a "Max Nx" badge,
+        // even if the tier string happens to contain a multiplier pattern.
+        #expect(formatPlanBadge(subscriptionType: "pro", rateLimitTier: "default_claude_max_20x") == "Pro")
+        #expect(formatPlanBadge(subscriptionType: "Pro", rateLimitTier: "some_tier_20x") == "Pro")
+        #expect(formatPlanBadge(subscriptionType: "enterprise", rateLimitTier: "default_claude_max_20x") == "Enterprise")
+    }
+
+    @Test("Requires _max_ in tier to apply multiplier (guards against false positives)")
+    func tierWithoutMaxSegment() {
+        // A Max subscription with a tier that has a multiplier but no "_max_" segment
+        // should fall through to plain "Max" capitalization.
+        #expect(formatPlanBadge(subscriptionType: "max", rateLimitTier: "some_20x_tier") == "Max")
+    }
 }
 
 // MARK: - formatCredits

--- a/Tests/ClaudeUsageTests/FormattingTests.swift
+++ b/Tests/ClaudeUsageTests/FormattingTests.swift
@@ -195,6 +195,58 @@ struct MenuBarLabelTests {
     }
 }
 
+// MARK: - formatPlanBadge
+
+@Suite("formatPlanBadge")
+struct PlanBadgeTests {
+
+    @Test("Returns 'Max 20x' for default_claude_max_20x tier")
+    func max20xTier() {
+        let result = formatPlanBadge(subscriptionType: "max", rateLimitTier: "default_claude_max_20x")
+        #expect(result == "Max 20x")
+    }
+
+    @Test("Returns 'Max' for default_claude_max_5x tier (base Max)")
+    func max5xTier() {
+        let result = formatPlanBadge(subscriptionType: "max", rateLimitTier: "default_claude_max_5x")
+        #expect(result == "Max")
+    }
+
+    @Test("Capitalizes raw subscriptionType when no multiplier in tier")
+    func capitalizesSubscriptionType() {
+        #expect(formatPlanBadge(subscriptionType: "max", rateLimitTier: "tier_2") == "Max")
+        #expect(formatPlanBadge(subscriptionType: "pro", rateLimitTier: "tier_1") == "Pro")
+    }
+
+    @Test("Capitalizes subscriptionType when rateLimitTier is nil")
+    func nilTier() {
+        #expect(formatPlanBadge(subscriptionType: "max", rateLimitTier: nil) == "Max")
+        #expect(formatPlanBadge(subscriptionType: "pro", rateLimitTier: nil) == "Pro")
+    }
+
+    @Test("Preserves already-capitalized subscriptionType")
+    func alreadyCapitalized() {
+        #expect(formatPlanBadge(subscriptionType: "Pro", rateLimitTier: nil) == "Pro")
+        #expect(formatPlanBadge(subscriptionType: "Max", rateLimitTier: nil) == "Max")
+    }
+
+    @Test("Returns nil when subscriptionType is nil")
+    func nilSubscription() {
+        #expect(formatPlanBadge(subscriptionType: nil, rateLimitTier: "default_claude_max_20x") == nil)
+    }
+
+    @Test("Returns nil when subscriptionType is empty")
+    func emptySubscription() {
+        #expect(formatPlanBadge(subscriptionType: "", rateLimitTier: "default_claude_max_20x") == nil)
+    }
+
+    @Test("Handles hypothetical future tiers like 100x")
+    func futureTier() {
+        let result = formatPlanBadge(subscriptionType: "max", rateLimitTier: "default_claude_max_100x")
+        #expect(result == "Max 100x")
+    }
+}
+
 // MARK: - formatCredits
 
 @Suite("formatCredits")

--- a/Tests/ClaudeUsageTests/Mocks.swift
+++ b/Tests/ClaudeUsageTests/Mocks.swift
@@ -281,13 +281,15 @@ enum TestData {
         accessToken: String = "test-access-token",
         refreshToken: String = "test-refresh-token",
         expiresAt: Date = Date(timeIntervalSinceNow: 3600),
-        subscriptionType: String? = "Pro"
+        subscriptionType: String? = "Pro",
+        rateLimitTier: String? = nil
     ) -> OAuthCredentials {
         OAuthCredentials(
             accessToken: accessToken,
             refreshToken: refreshToken,
             expiresAt: expiresAt,
-            subscriptionType: subscriptionType
+            subscriptionType: subscriptionType,
+            rateLimitTier: rateLimitTier
         )
     }
 }

--- a/Tests/ClaudeUsageTests/UsageServiceTests.swift
+++ b/Tests/ClaudeUsageTests/UsageServiceTests.swift
@@ -259,6 +259,70 @@ struct UsageServiceFetchTests {
         #expect(service.subscriptionType == "Max")
     }
 
+    @Test("Sets rateLimitTier from keychain credentials")
+    @MainActor
+    func rateLimitTierFromKeychain() async {
+        let (service, _, mockNetwork) = makeService(
+            credentials: TestData.mockCredentials(
+                subscriptionType: "max",
+                rateLimitTier: "default_claude_max_20x"
+            )
+        )
+        mockNetwork.enqueue(data: TestData.fullUsageJSON, statusCode: 200)
+
+        await service.fetchUsage()
+
+        #expect(service.rateLimitTier == "default_claude_max_20x")
+    }
+
+    @Test("planBadge returns 'Max 20x' for max20x credentials")
+    @MainActor
+    func planBadgeMax20x() async {
+        let (service, _, mockNetwork) = makeService(
+            credentials: TestData.mockCredentials(
+                subscriptionType: "max",
+                rateLimitTier: "default_claude_max_20x"
+            )
+        )
+        mockNetwork.enqueue(data: TestData.fullUsageJSON, statusCode: 200)
+
+        await service.fetchUsage()
+
+        #expect(service.planBadge == "Max 20x")
+    }
+
+    @Test("planBadge returns 'Max' for base max credentials")
+    @MainActor
+    func planBadgeMax5x() async {
+        let (service, _, mockNetwork) = makeService(
+            credentials: TestData.mockCredentials(
+                subscriptionType: "max",
+                rateLimitTier: "default_claude_max_5x"
+            )
+        )
+        mockNetwork.enqueue(data: TestData.fullUsageJSON, statusCode: 200)
+
+        await service.fetchUsage()
+
+        #expect(service.planBadge == "Max")
+    }
+
+    @Test("planBadge returns 'Pro' for pro credentials")
+    @MainActor
+    func planBadgePro() async {
+        let (service, _, mockNetwork) = makeService(
+            credentials: TestData.mockCredentials(
+                subscriptionType: "Pro",
+                rateLimitTier: "tier_1"
+            )
+        )
+        mockNetwork.enqueue(data: TestData.fullUsageJSON, statusCode: 200)
+
+        await service.fetchUsage()
+
+        #expect(service.planBadge == "Pro")
+    }
+
     @Test("Sets decodingFailed error for malformed response")
     @MainActor
     func fetchDecodingError() async {
@@ -700,18 +764,22 @@ struct UsageServiceFetchTests {
         await firstFetch.value
     }
 
-    @Test("Updates subscriptionType when keychain is re-read after 401")
+    @Test("Updates subscriptionType and rateLimitTier when keychain is re-read after 401")
     @MainActor
     func subscriptionTypeUpdatedOn401KeychainReread() async {
-        // Use explicit queue so first read returns Pro, second returns Max
+        // Use explicit queue so first read returns Pro, second returns Max 20x
         let (service, mockKeychain, mockNetwork) = makeService()
 
         // First keychain read (token init): Pro subscription
-        mockKeychain.enqueue(.success(TestData.mockCredentials(subscriptionType: "Pro")))
-        // Second keychain read (401 fallback): Max subscription
+        mockKeychain.enqueue(.success(TestData.mockCredentials(
+            subscriptionType: "Pro",
+            rateLimitTier: "tier_1"
+        )))
+        // Second keychain read (401 fallback): Max 20x subscription
         mockKeychain.enqueue(.success(TestData.mockCredentials(
             accessToken: "fresh-token",
-            subscriptionType: "Max"
+            subscriptionType: "max",
+            rateLimitTier: "default_claude_max_20x"
         )))
 
         // First fetch: 401
@@ -723,7 +791,9 @@ struct UsageServiceFetchTests {
 
         await service.fetchUsage()
 
-        #expect(service.subscriptionType == "Max")
+        #expect(service.subscriptionType == "max")
+        #expect(service.rateLimitTier == "default_claude_max_20x")
+        #expect(service.planBadge == "Max 20x")
         #expect(service.usage != nil)
     }
 }


### PR DESCRIPTION
## Summary
This PR adds support for tracking and displaying Claude subscription plan variants (e.g., "Max 20x") by introducing `rateLimitTier` tracking and a new `formatPlanBadge()` function that intelligently formats subscription information for display.

## Key Changes

- **Added `rateLimitTier` property to `UsageService`**: Now captures and stores the rate limit tier from keychain credentials alongside subscription type
- **Introduced `planBadge` computed property**: Derives a display-friendly plan badge (e.g., "Pro", "Max", "Max 20x") from subscription type and rate limit tier
- **New `formatPlanBadge()` function**: Intelligently formats plan information by:
  - Extracting multiplier values from tier identifiers (e.g., "default_claude_max_20x" → "20x")
  - Treating 5x as the base Max tier (displays as "Max" not "Max 5x")
  - Falling back to capitalized subscription type when no multiplier is present
  - Handling nil/empty subscription types gracefully
- **Updated keychain credential handling**: Both token initialization and 401 fallback paths now read and store `rateLimitTier`
- **Updated UI**: Changed menu bar label to use `planBadge` instead of raw `subscriptionType`
- **Comprehensive test coverage**: Added 8 new tests covering plan badge formatting for various tier combinations and edge cases

## Implementation Details

The `formatPlanBadge()` function uses regex pattern matching to extract multiplier values from tier identifiers, enabling future-proof support for new tier variants (e.g., "100x"). The 5x multiplier is treated as the base tier to avoid redundant labeling.

https://claude.ai/code/session_01YWNDPp147Y3MYdRKdRiBTV